### PR TITLE
Modernize app: use latest TF2, Streamlit, ML model

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-tensorflow-cpu==2.7.0
-streamlit==1.11.0
-click==8
+tensorflow-cpu==2.12.0
+streamlit==1.23.1

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -7,8 +7,9 @@ import tensorflow as tf
 
 "# Deep Dream :sleeping:"
 
-# Download an image and read it into a NumPy array.
+
 def download(url, max_dim=None):
+    """Download an image from a URL and read it into a NumPy array."""
     name = url.split("/")[-1]
     image_path = tf.keras.utils.get_file(name, origin=url)
     img = PIL.Image.open(image_path)
@@ -17,14 +18,14 @@ def download(url, max_dim=None):
     return np.array(img)
 
 
-# Normalize an image
 def deprocess(img):
+    """Normalize an image"""
     img = 255 * (img + 1.0) / 2.0
     return tf.cast(img, tf.uint8)
 
 
-# Convert an image to a byte array so users can download it
 def img_to_bytes(img):
+    """Convert a PIL image to a byte array so users can download it"""
     with BytesIO() as buf:
         result.save(buf, format="PNG")
         img_bytes = buf.getvalue()
@@ -32,7 +33,7 @@ def img_to_bytes(img):
 
 
 def random_roll(img, maxroll):
-    # Randomly shift the image to avoid tiled boundaries.
+    """Randomly shift the image to avoid tiled boundaries."""
     shift = tf.random.uniform(
         shape=[2], minval=-maxroll, maxval=maxroll, dtype=tf.int32
     )
@@ -54,8 +55,8 @@ def load_dream_model(base_model, layers):
     return tf.keras.Model(inputs=base_model.input, outputs=layers)
 
 
-# Display an image
 def show(dg, img):
+    """Display an image."""
     dg.image(PIL.Image.fromarray(np.array(img)), use_column_width=True)
     return dg
 
@@ -67,7 +68,7 @@ def show(dg, img):
 
 
 def calc_loss(img, model):
-    # Pass forward the image through the model to retrieve the activations.
+    """Pass forward the image through the model to retrieve the activations."""
     img_batch = tf.expand_dims(img, axis=0)
     layer_activations = model(img_batch)
     if len(layer_activations) == 1:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -159,58 +159,55 @@ st.sidebar.caption(
 [TensorFlow's DeepDream tutorial](https://github.com/tensorflow/docs/blob/9ae740ab7b5b3f9c32ca060332037b51d95674ae/site/en/tutorials/generative/deepdream.ipynb)."""
 )
 
-with st.sidebar.form(key="my_form"):
-    url = st.text_input(
-        "Image URL",
-        "https://storage.googleapis.com/download.tensorflow.org/example_images/YellowLabradorLooking_new.jpg",
-        help="The URL of the image to use as a starting point for Deep Dream.",
-    )
+url = st.sidebar.text_input(
+    "Image URL",
+    "https://storage.googleapis.com/download.tensorflow.org/example_images/YellowLabradorLooking_new.jpg",
+    help="The URL of the image to use as a starting point for Deep Dream.",
+)
 
-    uploaded_file = st.file_uploader(
-        "Upload your own image...",
-        type="jpg",
-        help="Upload an image from your computer to use as a starting point for Deep Dream.",
-    )
+uploaded_file = st.sidebar.file_uploader(
+    "Upload your own image...",
+    type="jpg",
+    help="Upload an image from your computer to use as a starting point for Deep Dream.",
+)
 
-    octaves = st.slider(
-        "Octaves",
-        min_value=-2,
-        max_value=3,
-        value=(-1, 0),
-        step=1,
-        help="The number of scales at which to run gradient ascent.",
-    )
-    steps_per_octave = st.slider(
-        "Steps per Octave",
-        min_value=10,
-        max_value=100,
-        value=50,
-        step=10,
-        help="The number of gradient ascent steps to run at each octave.",
-    )
-    step_size = st.slider(
-        "Step Size",
-        min_value=0.01,
-        max_value=0.1,
-        value=0.01,
-        step=0.01,
-        help="The step size for gradient ascent.",
-    )
+octaves = st.sidebar.slider(
+    "Octaves",
+    min_value=-2,
+    max_value=3,
+    value=(-1, 0),
+    step=1,
+    help="The number of scales at which to run gradient ascent.",
+)
+steps_per_octave = st.sidebar.slider(
+    "Steps per Octave",
+    min_value=10,
+    max_value=100,
+    value=50,
+    step=10,
+    help="The number of gradient ascent steps to run at each octave.",
+)
+step_size = st.sidebar.slider(
+    "Step Size",
+    min_value=0.01,
+    max_value=0.1,
+    value=0.01,
+    step=0.01,
+    help="The step size for gradient ascent.",
+)
 
-    names = st.multiselect(
-        "Select layers to visualize",
-        list(all_layers.keys()),
-        default=["mixed3", "mixed5"],
-        help="""
-        For DeepDream, the layers of interest are those where the convolutions are concatenated. 
-        There are 11 of these layers in InceptionV3, named 'mixed0' though 'mixed10'. \n\n
-        Using different layers will result in different dream-like images. Deeper layers respond 
-        to higher-level features (such as eyes and faces), while earlier layers respond to simpler 
-        features (such as edges, shapes, and textures).
-        Source: [TensorFlow DeepDream](https://www.tensorflow.org/tutorials/generative/deepdream?hl=en#prepare_the_feature_extraction_model)""",
-    )
-
-    btn = st.form_submit_button(label="Start dreaming... :sleeping: :magic_wand:")
+names = st.sidebar.multiselect(
+    "Select layers to visualize",
+    list(all_layers.keys()),
+    default=["mixed3", "mixed5"],
+    help="""
+    For DeepDream, the layers of interest are those where the convolutions are concatenated. 
+    There are 11 of these layers in InceptionV3, named 'mixed0' though 'mixed10'. \n\n
+    Using different layers will result in different dream-like images. Deeper layers respond 
+    to higher-level features (such as eyes and faces), while earlier layers respond to simpler 
+    features (such as edges, shapes, and textures).
+    Source: [TensorFlow DeepDream](https://www.tensorflow.org/tutorials/generative/deepdream?hl=en#prepare_the_feature_extraction_model)""",
+)
 
 # Retrieve specific user-chosen layers from multiselect
 layers = [all_layers[name] for name in names]
@@ -227,22 +224,20 @@ else:
 st.subheader("Original Image")
 st.image(original_img, use_column_width=True)
 
-if btn:
-    st.subheader("Deep Dream Image")
-    image_widget = st.empty()
-    result = run_deep_dream_with_octaves(
-        img=original_img,
-        steps_per_octave=steps_per_octave,
-        step_size=step_size,
-        octaves=octaves,
-    )
-    st.balloons()
+st.subheader("Deep Dream Image")
+image_widget = st.empty()
+result = run_deep_dream_with_octaves(
+    img=original_img,
+    steps_per_octave=steps_per_octave,
+    step_size=step_size,
+    octaves=octaves,
+)
 
-    img_bytes = img_to_bytes(result)
+img_bytes = img_to_bytes(result)
 
-    st.download_button(
-        label="Download Deep Dream Image",
-        data=img_bytes,
-        file_name="deep_dream.png",
-        mime="image/png",
-    )
+st.download_button(
+    label="Download Deep Dream Image",
+    data=img_bytes,
+    file_name="deep_dream.png",
+    mime="image/png",
+)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,231 +1,248 @@
 from io import BytesIO
-import PIL.Image
+
 import numpy as np
-import os
-import requests
+import PIL.Image
 import streamlit as st
-import subprocess
 import tensorflow as tf
-import urllib
-import zipfile
 
-'# Deeeeeeep dreeeeeeeeeam ~_~'
+"# Deep Dream :sleeping:"
 
-
-# Basic setup
-
-THIS_FILE_DIR = os.path.abspath(os.path.dirname(__file__))
-MODEL_DIR = os.path.join(THIS_FILE_DIR, 'models')
-MODEL_FILENAME = os.path.join(MODEL_DIR, 'tensorflow_inception_graph.pb')
-
-
-@st.cache
-def download_model_from_web():
-    if os.path.isfile(MODEL_FILENAME):
-        return
-
-    try:
-        os.mkdir(MODEL_DIR)
-    except FileExistsError:
-        pass
-
-    MODEL_ZIP_URL = (
-        'https://storage.googleapis.com/download.tensorflow.org/models/'
-        'inception5h.zip')
-    ZIP_FILE_NAME = 'inception5h.zip'
-    ZIP_FILE_PATH = os.path.join(MODEL_DIR, ZIP_FILE_NAME)
-    resp = requests.get(MODEL_ZIP_URL, stream=True)
-
-    with open(ZIP_FILE_PATH, 'wb') as file_desc:
-        for chunk in resp.iter_content(chunk_size=5000000):
-            file_desc.write(chunk)
-
-    zip_file = zipfile.ZipFile(ZIP_FILE_PATH)
-    zip_file.extractall(path=MODEL_DIR)
-
-    os.remove(ZIP_FILE_PATH)
+# Download an image and read it into a NumPy array.
+def download(url, max_dim=None):
+    name = url.split("/")[-1]
+    image_path = tf.keras.utils.get_file(name, origin=url)
+    img = PIL.Image.open(image_path)
+    if max_dim:
+        img.thumbnail((max_dim, max_dim))
+    return np.array(img)
 
 
-@st.cache(allow_output_mutation=True)
-def init_model():
-    with tf.compat.v1.gfile.FastGFile(MODEL_FILENAME, 'rb') as f:
-        graph_def = tf.compat.v1.GraphDef()
-        graph_def.ParseFromString(f.read())
-    return graph_def
+# Normalize an image
+def deprocess(img):
+    img = 255 * (img + 1.0) / 2.0
+    return tf.cast(img, tf.uint8)
 
 
-download_model_from_web()
-graph_def = init_model()
+# Convert an image to a byte array so users can download it
+def img_to_bytes(img):
+    with BytesIO() as buf:
+        result.save(buf, format="PNG")
+        img_bytes = buf.getvalue()
+    return img_bytes
 
-graph = tf.Graph()
-sess = tf.compat.v1.InteractiveSession(graph=graph)
+
+def random_roll(img, maxroll):
+    # Randomly shift the image to avoid tiled boundaries.
+    shift = tf.random.uniform(
+        shape=[2], minval=-maxroll, maxval=maxroll, dtype=tf.int32
+    )
+    img_rolled = tf.roll(img, shift=shift, axis=[0, 1])
+    return shift, img_rolled
+
+
+@st.cache_resource
+def load_base_model():
+    return tf.keras.applications.InceptionV3(include_top=False, weights="imagenet")
+
+
+@st.cache_resource
+def load_all_layers(_model):
+    return {layer.name: layer.output for layer in _model.layers}
+
+
+def load_dream_model(base_model, layers):
+    return tf.keras.Model(inputs=base_model.input, outputs=layers)
+
+
+# Display an image
+def show(dg, img):
+    dg.image(PIL.Image.fromarray(np.array(img)), use_column_width=True)
+    return dg
 
 
 # Below is the actual logic for this app. It's a bit messy because it's almost a
 # straight copy/paste from the original DeepDream example repo, which is also
 # messy:
-# https://github.com/tensorflow/tensorflow/tree/master/tensorflow/examples/tutorials/deepdream
-
-t_input = tf.compat.v1.placeholder(np.float32, name='input')
-imagenet_mean = 117.0
-t_preprocessed = tf.expand_dims(t_input - imagenet_mean, 0)
-tf.import_graph_def(graph_def, {'input': t_preprocessed})
+# https://github.com/tensorflow/docs/blob/9ae740ab7b5b3f9c32ca060332037b51d95674ae/site/en/tutorials/generative/deepdream.ipynb
 
 
-def get_tensor(layer):
-    '''Helper for getting layer output tensor'''
-    return graph.get_tensor_by_name('%s:0' % layer)
+def calc_loss(img, model):
+    # Pass forward the image through the model to retrieve the activations.
+    img_batch = tf.expand_dims(img, axis=0)
+    layer_activations = model(img_batch)
+    if len(layer_activations) == 1:
+        layer_activations = [layer_activations]
+
+    losses = []
+    for act in layer_activations:
+        loss = tf.math.reduce_mean(act)
+        losses.append(loss)
+
+    return tf.reduce_sum(losses)
 
 
-# Start with a gray image with a little noise.
-img_noise = np.random.uniform(size=(224, 224, 3)) + 100.0
+class TiledGradients(tf.Module):
+    def __init__(self, model):
+        self.model = model
+
+    @tf.function(
+        input_signature=(
+            tf.TensorSpec(shape=[None, None, 3], dtype=tf.float32),
+            tf.TensorSpec(shape=[2], dtype=tf.int32),
+            tf.TensorSpec(shape=[], dtype=tf.int32),
+        )
+    )
+    def __call__(self, img, img_size, tile_size=512):
+        shift, img_rolled = random_roll(img, tile_size)
+        gradients = tf.zeros_like(img_rolled)
+        xs = tf.range(0, img_size[1], tile_size)[:-1]
+        if not tf.cast(len(xs), bool):
+            xs = tf.constant([0])
+        ys = tf.range(0, img_size[0], tile_size)[:-1]
+        if not tf.cast(len(ys), bool):
+            ys = tf.constant([0])
+
+        for x in xs:
+            for y in ys:
+                with tf.GradientTape() as tape:
+                    tape.watch(img_rolled)
+                    img_tile = img_rolled[y : y + tile_size, x : x + tile_size]
+                    loss = calc_loss(img_tile, self.model)
+                gradients = gradients + tape.gradient(loss, img_rolled)
+
+        gradients = tf.roll(gradients, shift=-shift, axis=[0, 1])
+        gradients /= tf.math.reduce_std(gradients) + 1e-8
+        return gradients
 
 
-def write_image(dg, arr):
-    arr = np.uint8(np.clip(arr/255.0, 0, 1)*255)
-    dg.image(arr, use_column_width=True)
-    return dg
+def run_deep_dream_with_octaves(
+    img, steps_per_octave=100, step_size=0.01, octaves=range(-2, 3), octave_scale=1.3
+):
+    base_shape = tf.shape(img)
+    img = tf.keras.utils.img_to_array(img)
+    img = tf.keras.applications.inception_v3.preprocess_input(img)
 
+    initial_shape = img.shape[:-1]
+    img = tf.image.resize(img, initial_shape)
 
-def tffunc(*argtypes):
-    '''Helper that transforms TF-graph generating function into a regular one.
-
-    See "resize" function below.
-    '''
-    placeholders = list(map(tf.compat.v1.placeholder, argtypes))
-
-    def wrap(f):
-        out = f(*placeholders)
-
-        def wrapper(*args, **kw):
-            return out.eval(
-                dict(zip(placeholders, args)), session=kw.get('session'))
-        return wrapper
-    return wrap
-
-
-# Helper function that uses TF to resize an image
-def resize(img, size):
-    img = tf.expand_dims(img, 0)
-    return tf.compat.v1.image.resize_bilinear(img, size)[0, :, :, :]
-
-
-resize = tffunc(np.float32, np.int32)(resize)
-
-
-def calc_grad_tiled(img, t_grad, tile_size=512):
-    '''Compute the value of tensor t_grad over the image in a tiled way.
-
-    Random shifts are applied to the image to blur tile boundaries over
-    multiple iterations.
-    '''
-    sz = tile_size
-    h, w = img.shape[:2]
-    sx, sy = np.random.randint(sz, size=2)
-    img_shift = np.roll(np.roll(img, sx, 1), sy, 0)
-    grad = np.zeros_like(img)
-    for y in range(0, max(h-sz//2, sz), sz):
-        for x in range(0, max(w-sz//2, sz), sz):
-            sub = img_shift[y:y+sz, x:x+sz]
-            g = sess.run(t_grad, {t_input: sub})
-            grad[y:y+sz, x:x+sz] = g
-    return np.roll(np.roll(grad, -sx, 1), -sy, 0)
-
-
-def do_deepdream(
-        t_obj, img_in=img_noise, iter_n=10, step=1.5, octave_n=4,
-        octave_scale=1.4):
-    t_score = tf.reduce_mean(t_obj)
-    t_grad = tf.gradients(t_score, t_input)[0]
-
-    # split the image into a number of octaves
-    octaves = []
-    for i in range(octave_n-1):
-        hw = img_in.shape[:2]
-        lo = resize(img_in, np.int32(np.float32(hw)/octave_scale))
-        hi = img_in-resize(lo, hw)
-        img_in = lo
-        octaves.append(hi)
-
-    image_widget = st.empty()
-    text_template = 'Octave: %s\nIteration: %s'
-    text_widget = st.sidebar.text(text_template % (0, 0))
+    text_template = "Octave: %s\n\nStep: %s"
     progress_widget = st.sidebar.progress(0)
     p = 0.0
 
-    # generate details octave by octave
-    for octave in range(octave_n):
-        if octave > 0:
-            hi = octaves[-octave]
-            img_in = resize(img_in, hi.shape[:2])+hi
-        for i in range(iter_n):
-            g = calc_grad_tiled(img_in, t_grad)
-            img_in += g*(step / (np.abs(g).mean()+1e-7))
+    for octave in octaves:
+        new_size = tf.cast(tf.convert_to_tensor(base_shape[:-1]), tf.float32) * (
+            octave_scale**octave
+        )
+        new_size = tf.cast(new_size, tf.int32)
+        img = tf.image.resize(img, new_size)
+        for step in range(steps_per_octave):
+            gradients = get_tiled_gradients(img, new_size)
+            img = img + gradients * step_size
+            img = tf.clip_by_value(img, -1, 1)
             p += 1
-            progress_widget.progress(p / (octave_n * iter_n))
-
-            write_image(image_widget, img_in)
-            text_widget.text(text_template % (octave, i))
-
-
-layers = [
-    op.name for op in graph.get_operations()
-    if op.type == 'Conv2D' and 'import/' in op.name
-    ]
+            progress_widget.progress(
+                p / (steps_per_octave * len(octaves)),
+                text_template % (octave, step + 1),
+            )
+            if step % 10 == 0:
+                show(image_widget, deprocess(img))
+    result = PIL.Image.fromarray(np.array(deprocess(img)))
+    return result
 
 
-@st.cache()
-def read_file_from_url(url):
-    return urllib.request.urlopen(url).read()
+# Load and cache the base model and all layers
+base_model = load_base_model()
+all_layers = load_all_layers(base_model)
 
+st.sidebar.caption(
+    """This Streamlit app is based entirely on
+[TensorFlow's DeepDream tutorial](https://github.com/tensorflow/docs/blob/9ae740ab7b5b3f9c32ca060332037b51d95674ae/site/en/tutorials/generative/deepdream.ipynb)."""
+)
 
-# Sidebar controls:
+with st.sidebar.form(key="my_form"):
+    url = st.text_input(
+        "Image URL",
+        "https://storage.googleapis.com/download.tensorflow.org/example_images/YellowLabradorLooking_new.jpg",
+        help="The URL of the image to use as a starting point for Deep Dream.",
+    )
 
-# Temporary config option to remove deprecation warning.
-st.set_option('deprecation.showfileUploaderEncoding', False)
+    uploaded_file = st.file_uploader(
+        "Upload your own image...",
+        type="jpg",
+        help="Upload an image from your computer to use as a starting point for Deep Dream.",
+    )
 
-MAX_IMG_WIDTH = 600
-MAX_IMG_HEIGHT = 400
-DEFAULT_IMAGE_URL = 'https://i.imgur.com/dOPMzXl.jpg'
+    octaves = st.slider(
+        "Octaves",
+        min_value=-2,
+        max_value=3,
+        value=(-1, 0),
+        step=1,
+        help="The number of scales at which to run gradient ascent.",
+    )
+    steps_per_octave = st.slider(
+        "Steps per Octave",
+        min_value=10,
+        max_value=100,
+        value=50,
+        step=10,
+        help="The number of gradient ascent steps to run at each octave.",
+    )
+    step_size = st.slider(
+        "Step Size",
+        min_value=0.01,
+        max_value=0.1,
+        value=0.01,
+        step=0.01,
+        help="The step size for gradient ascent.",
+    )
 
+    names = st.multiselect(
+        "Select layers to visualize",
+        list(all_layers.keys()),
+        default=["mixed3", "mixed5"],
+        help="""
+        For DeepDream, the layers of interest are those where the convolutions are concatenated. 
+        There are 11 of these layers in InceptionV3, named 'mixed0' though 'mixed10'. \n\n
+        Using different layers will result in different dream-like images. Deeper layers respond 
+        to higher-level features (such as eyes and faces), while earlier layers respond to simpler 
+        features (such as edges, shapes, and textures).
+        Source: [TensorFlow DeepDream](https://www.tensorflow.org/tutorials/generative/deepdream?hl=en#prepare_the_feature_extraction_model)""",
+    )
 
-file_obj = st.sidebar.file_uploader('Choose an image:', ('jpg', 'jpeg'))
+    btn = st.form_submit_button(label="Start dreaming... :sleeping: :magic_wand:")
 
-if not file_obj:
-    file_obj = BytesIO(read_file_from_url(DEFAULT_IMAGE_URL))
+# Retrieve specific user-chosen layers from multiselect
+layers = [all_layers[name] for name in names]
+dream_model = load_dream_model(base_model, layers)
+get_tiled_gradients = TiledGradients(dream_model)
 
-img_in = PIL.Image.open(file_obj)
+if uploaded_file is not None:
+    original_img = PIL.Image.open(uploaded_file)
+    original_img.thumbnail((500, 500))
+    original_img = np.array(original_img.copy())
+else:
+    original_img = download(url, max_dim=500)
 
-img_in.thumbnail((MAX_IMG_WIDTH, MAX_IMG_HEIGHT), PIL.Image.ANTIALIAS)
-img_in = np.float32(img_in)
+st.subheader("Original Image")
+st.image(original_img, use_column_width=True)
 
+if btn:
+    st.subheader("Deep Dream Image")
+    image_widget = st.empty()
+    result = run_deep_dream_with_octaves(
+        img=original_img,
+        steps_per_octave=steps_per_octave,
+        step_size=step_size,
+        octaves=octaves,
+    )
+    st.balloons()
 
-# Picking some internal layer. Note that we use outputs before applying the
-# ReLU nonlinearity to have non-zero gradients for features with negative
-# initial activations.
+    img_bytes = img_to_bytes(result)
 
-max_value = len(layers) - 1
-layer_num = st.sidebar.slider('Layer to visualize', 0, max_value, min(58, max_value))
-layer = layers[layer_num]
-
-channels = int(get_tensor(layer).get_shape()[-1])
-max_value = channels - 1
-channel = st.sidebar.slider('Channel to visualize', 0, max_value, min(62, max_value))
-
-octaves = st.sidebar.slider('Octaves', 1, 30, 4)
-
-iterations = st.sidebar.slider('Iterations per octave', 1, 30, 10)
-
-
-# Show original image and final image, computing DeepDream on it iteratively.
-
-'## Original image'
-
-write_image(st, img_in)
-
-
-'## Output'
-
-out = do_deepdream(
-    get_tensor(layer)[:, :, :, channel], img_in, octave_n=octaves,
-    iter_n=iterations)
+    st.download_button(
+        label="Download Deep Dream Image",
+        data=img_bytes,
+        file_name="deep_dream.png",
+        mime="image/png",
+    )

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -189,7 +189,7 @@ if image_source == "Specify image by URL...":
 elif image_source == "Upload image from my machine...":
     uploaded_file = st.sidebar.file_uploader(
         "Upload your own image...",
-        type="jpg",
+        type=["jpg", "png"],
         help="Upload an image from your computer to use as a starting point for Deep Dream.\n\nUses the same image as the 'Yellow labrador example' if no image is uploaded.",
     )
     if uploaded_file is not None:


### PR DESCRIPTION
There are a number of critical issues with the existing app:
- Deployed on Community Cloud using Python 3.7 (which is reaching EOL this month)
- Uses a 3+ year old Inceptionh5 model (deprecated and equivalent to V1) that was trained with TF1. The field has moved on to InceptionV3.
- Queries Imgur for an image. Imgur has rate-limited Streamlit, so the app returns `HTTP Error 429`.
- Uses the deprecated `@st.cache` decorator which leaks memory and is inefficient
- Uses an old version of Streamlit from 2022: 1.11.1
- Based on a 3+ old TensorFlow tutorial which is no longer available
- ML model runs on first app view and reruns immediately when widget inputs change, causing the app to always appear sluggish (rather than using `st.form`)

This PR fixes those issues. Verify in the staging app below.
[![Streamlit App](https://static.streamlit.io/badges/streamlit_badge_black_white.svg)](https://streamlit-demo-deepdream-streamlit-app-deepdream-v2-5ts3vj.streamlit.app/)